### PR TITLE
libretro: Remove second call to unload_game()

### DIFF
--- a/examples/libretro/tic80_libretro.c
+++ b/examples/libretro/tic80_libretro.c
@@ -152,9 +152,6 @@ void retro_init(void)
  */
 void retro_deinit(void)
 {
-	// Try to force another unload of the game.
-	retro_unload_game();
-
 	// Clear out the frame buffer.
 	free(frame_buf);
 	frame_buf = NULL;


### PR DESCRIPTION
Thanks to @fr500 for this recommendation.